### PR TITLE
Added support for SSL client certificates

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -27,4 +27,108 @@ class Config extends GlobalVarConfig {
 	public static function getVersion() {
 		return self::VERSION;
 	}
+
+	/**
+	 * Helper function to retrieve SSL config as object
+	 *
+	 * @return stdClass
+	 */
+        public static function getSSLConfig()
+        {
+                $sslconfig = new \stdClass;
+
+                $sslconfig->enabled = $GLOBALS["LDAPAuthentication2SSLClientCertEnabled"];
+                $sslconfig->prefix = $GLOBALS["LDAPAuthentication2SSLClientCertPrefix"];
+                $sslconfig->field = $GLOBALS["LDAPAuthentication2SSLClientCertField"];
+                $sslconfig->fieldParse = $GLOBALS["LDAPAuthentication2SSLClientCertFieldParse"];
+                $sslconfig->fieldSeparator = $GLOBALS["LDAPAuthentication2SSLClientCertFieldSeparator"];
+                $sslconfig->keyValueSeparator = $GLOBALS["LDAPAuthentication2SSLClientCertKeyValueSeparator"];
+                $sslconfig->keySelector = $GLOBALS["LDAPAuthentication2SSLClientCertKeySelector"];
+                $sslconfig->valueSeparators = $GLOBALS["LDAPAuthentication2SSLClientCertValueSeparators"];
+                $sslconfig->requirePassword = $GLOBALS["LDAPAuthentication2SSLClientCertRequirePassword"];
+                $sslconfig->autoLogin = $GLOBALS["LDAPAuthentication2SSLClientCertAutoLogin"];
+
+                return $sslconfig;
+        }
+        
+	/**
+	 * Helper function to retrieve SSL client cert username
+	 *
+	 * @return string
+	 */
+        public static function getSSLUsername()
+        {
+                $sslconfig = self::getSSLConfig();
+                
+                if (!$sslconfig->prefix)
+                        $sslconfig->prefix = "SSL_CLIENT_S_";
+
+                if (!$sslconfig->field)
+                        return null;
+
+                if (!$sslconfig->fieldParse)
+                {
+                        if (isset($_SERVER[$sslconfig->prefix.$sslconfig->field]))
+                                return $_SERVER[$sslconfig->prefix.$sslconfig->field];
+                        else
+                                return null;
+                }
+
+                if (!$sslconfig->keySelector)
+                        return null;
+
+                $fields = explode($sslconfig->fieldSeparator, $_SERVER[$sslconfig->prefix.$sslconfig->field]);
+
+                if (!count($fields))
+                        return null;
+
+                $username = null;
+
+                foreach ($fields as $keyvalue)
+                {
+                        if ($sslconfig->keyValueSeparator)
+                        {
+                                $keyval = explode($sslconfig->keyValueSeparator, $keyvalue);
+
+                                $key = $keyval[0];
+                                $val = ((isset($keyval[1])) ? $keyval[1] : null);
+
+                                if ($key == $sslconfig->keySelector)
+                                {
+                                        if ($sslconfig->valueSeparators)
+                                        {
+                                                if (is_array($sslconfig->valueSeparators))
+                                                {
+                                                        foreach ($sslconfig->valueSeparators as $sepkey => $sepvalue)
+                                                        {
+                                                                $sepval = explode($sepkey, $val);
+                                                                $val = ((isset($sepval[$sepvalue])) ? $sepval[$sepvalue] : $val);
+                                                        }
+                                                }
+                                                else
+                                                {
+                                                        $sepval = explode($sslconfig->valueSeparators, $val);
+                                                        $val = $sepval[0];
+                                                }
+                                        }
+
+                                        $username = $val;
+                                        break;
+                                }
+                        }
+                        else
+                        {
+                                if ($keyvalue == $sslconfig->keySelector)
+                                {
+                                        $username = $keyvalue;
+                                        break;
+                                }
+                        }
+                }
+
+                if ($username)
+                        return $username;
+
+                return null;
+        }
 }

--- a/src/ExtraLoginFields.php
+++ b/src/ExtraLoginFields.php
@@ -7,6 +7,7 @@ class ExtraLoginFields extends \ArrayObject {
 	const DOMAIN = 'domain';
 	const USERNAME = 'username';
 	const PASSWORD = 'password';
+	const SSLUSER = 'ssluser';
 
 	const DOMAIN_VALUE_LOCAL = 'local';
 
@@ -15,22 +16,73 @@ class ExtraLoginFields extends \ArrayObject {
 	 * @param Config $config Config for this extension
 	 */
 	public function __construct( array $configuredDomains, $config ) {
-		parent::__construct( [
-			static::DOMAIN => $this->makeDomainFieldDescriptor( $configuredDomains, $config ),
-			static::USERNAME => [
-				'type' => 'string',
-				'label' => wfMessage( 'userlogin-yourname' ),
-				'help' => wfMessage( 'authmanager-username-help' ),
-			],
-			static::PASSWORD => [
-				'type' => 'password',
-				'label' => wfMessage( 'userlogin-yourpassword' ),
-				'help' => wfMessage( 'authmanager-password-help' ),
-				'sensitive' => true,
-			]
-		] );
-	}
+		$sslconfig = $config->getSSLConfig();
+		$default_login = false;
 
+		if ($sslconfig->enabled)
+		{
+			if ($config::getSSLUsername())
+			{
+				if ($sslconfig->requirePassword)
+					parent::__construct( [
+						static::DOMAIN => $this->makeDomainFieldDescriptor( $configuredDomains, $config ),
+						static::SSLUSER => $this->makeSSLUserFieldDescriptor( $config ),
+						static::PASSWORD => $this->makePasswordFieldDescriptor()
+					] );
+				else
+					parent::__construct( [
+						static::DOMAIN => $this->makeDomainFieldDescriptor( $configuredDomains, $config ),
+						static::SSLUSER => $this->makeSSLUserFieldDescriptor( $config )
+					] );
+			}
+			else
+			{
+				$default_login = true;
+			}
+		}
+		else
+		{
+			$default_login = true;
+		}
+		
+		if ($default_login)
+		{
+			parent::__construct( [
+				static::DOMAIN => $this->makeDomainFieldDescriptor( $configuredDomains, $config ),
+				static::USERNAME => $this->makeUsernameFieldDescriptor(),
+				static::PASSWORD => $this->makePasswordFieldDescriptor()
+				
+			] );
+		}
+	}
+	
+	private function makeSSLUserFieldDescriptor($config)
+	{
+		return [
+			'type' => 'hidden',
+			'value' => $config::getSSLUsername()
+		];
+	}
+	
+	private function makeUsernameFieldDescriptor() 
+	{		
+		return [
+			'type' => 'string',
+			'label' => wfMessage( 'userlogin-yourname' ),
+			'help' => wfMessage( 'authmanager-username-help' ),
+		];
+	}
+	
+	private function makePasswordFieldDescriptor() 
+	{		
+		return [
+			'type' => 'password',
+			'label' => wfMessage( 'userlogin-yourpassword' ),
+			'help' => wfMessage( 'authmanager-password-help' ),
+			'sensitive' => true,
+		];
+	}
+	
 	private function makeDomainFieldDescriptor( $configuredDomains, $config ) {
 		if ( $config->get( 'AllowLocalLogin' ) ) {
 			$configuredDomains[] = static::DOMAIN_VALUE_LOCAL;

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -34,5 +34,53 @@ class Setup {
 		if ( $out->getTitle()->isSpecial( 'Userlogin' ) && $config->get( 'AllowLocalLogin' ) ) {
 			$out->addInlineStyle( '#wpLoginAttempt { display: none; }' );
 		}
+		
+		$sslconfig = Config::newInstance()->getSSLConfig();
+
+		if (($sslconfig->enabled) && (!$sslconfig->requirePassword) && ($sslconfig->autoLogin))
+			$out->addScript( '<script type="text/javascript">
+			function minuteCookie(cname, cvalue) {
+				var d = new Date();
+				d.setTime(d.getTime() + (3*60*1000));
+				var expires = "expires="+ d.toUTCString();
+ 				document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+			}
+			function getCookie(cname) {
+				var name = cname + "=";
+				var decodedCookie = decodeURIComponent(document.cookie);
+				var ca = decodedCookie.split(";");
+				for(var i = 0; i <ca.length; i++) {
+				  var c = ca[i];
+				  while (c.charAt(0) == " ") {
+				    c = c.substring(1);
+				  }
+				  if (c.indexOf(name) == 0) {
+				    return c.substring(name.length, c.length);
+				  }
+				}
+				return "";
+			}
+			function autoClick()
+			{
+				minuteCookie("logintry", 1);
+				document.getElementById("mw-input-pluggableauthlogin").click();			
+			}
+			var tryCookie = getCookie("logintry");
+			if (tryCookie == "")
+			{
+				if (document.getElementsByClassName("errorbox").length == 0)
+				{
+					if (!!document.getElementById("mw-input-captchaWord") === false)
+					{
+						if (!!document.getElementsByClassName("mw-userlogin-rememberme") === true)
+							document.getElementsByClassName("mw-userlogin-rememberme")[0].style.display = "none";
+					
+						document.getElementById("mw-input-pluggableauthlogin").style.display = "none";
+
+						setTimeout("autoClick()", 1100);
+					}
+				}
+			}
+			</script>' );
 	}
 }


### PR DESCRIPTION
Added support for SSL client certificates with LDAP backend boundary.

Now, you can use client certificates to deliver a username, which is checked against LDAP. Also a script based auto-login feature has been implemented.